### PR TITLE
🔥 音色ねいろホストの記述を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@
 [SHIELDS-GITHUB-LICENSE]: https://img.shields.io/github/license/Twitter-FFAC/fight-for-artistic-creativity.svg
 [SHIELDS-GITHUB-STARS]: https://img.shields.io/github/stars/Twitter-FFAC/fight-for-artistic-creativity.svg
 [SHIELDS-GITHUB-WATCHERS]: https://img.shields.io/github/watchers/Twitter-FFAC/fight-for-artistic-creativity.svg
-[SHIELDS-WEBSITE-NIROT1R]: https://img.shields.io/website-online-offline-green-red/https/ffac.g-second.net.svg?label=status
 [SHIELDS-WEBSITE-RIKU6460]: https://img.shields.io/website-online-offline-green-red/https/ffac.riku.pw.svg?label=status
 [SHIELDS-WEBSITE-MAK0TIA]: https://img.shields.io/website-online-offline-green-red/https/ffac.makotia.me.svg?label=status
 [TWITTER-ACID-CHICKEN]: https://twitter.com/acid_chicken
@@ -69,7 +68,6 @@
 
 |                      Region | Status                      | URL                         |
 |----------------------------:|:----------------------------|:----------------------------|
-|  [nirot1r][GITHUB-NIROT1R]  | ![SHIELDS-WEBSITE-NIROT1R]  | <https://ffac.g-second.net> |
 | [riku6460][GITHUB-RIKU6460] | ![SHIELDS-WEBSITE-RIKU6460] | <https://ffac.riku.pw>      |
 |  [mak0tia][GITHUB-MAK0TIA]  | ![SHIELDS-WEBSITE-MAK0TIA]  | <https://ffac.makotia.me>   |
 


### PR DESCRIPTION
# 概要

今後不必要だと判断し、ffac.g-second.netを停止したため。